### PR TITLE
Shorten chat IDs to 8 hex chars

### DIFF
--- a/desktop/src/main/chat-registry.ts
+++ b/desktop/src/main/chat-registry.ts
@@ -295,7 +295,7 @@ export class ChatRegistry {
   // ── Chat lifecycle ──
 
   async createChat(opts: CreateChatOpts): Promise<{ chat: ChatRecord }> {
-    const chatId = crypto.randomUUID()
+    const chatId = crypto.randomUUID().slice(0, 8)
     const now = Date.now()
     const llmCommand = this.resolveLlmCommand(opts.llmCommand)
     const dirPath = await createChatDir(chatId)
@@ -365,7 +365,7 @@ export class ChatRegistry {
       throw new Error(`Max nesting depth (${maxDepth}) reached`)
     }
 
-    const chatId = crypto.randomUUID()
+    const chatId = crypto.randomUUID().slice(0, 8)
     const now = Date.now()
     const llmCommand = this.resolveLlmCommand(opts.llmCommand, parent.llmCommand)
     const dirPath = await createChatDir(chatId, parent.dirPath)


### PR DESCRIPTION
## Summary
- Truncates chat IDs from full UUID v4 (36 chars) to the first 8 hex chars
- Matches the pattern already used for schedule IDs and MCP session IDs
- Chat dirs become `~/.parlour/chats/a1b2c3d4/` instead of `~/.parlour/chats/919f5e18-075a-481c-9323-fd208a1f8b41/`

## Test plan
- [ ] Create a new chat, verify the directory name is 8 hex chars
- [ ] Create a child chat (via dispatch), verify same short ID format
- [ ] Verify existing chats with full UUIDs still load on app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)