### PR TITLE
Fix clickable links in terminal

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, app, BrowserWindow } from 'electron'
+import { ipcMain, dialog, app, BrowserWindow, shell } from 'electron'
 import { join } from 'path'
 import { homedir } from 'os'
 import { mkdir, rm, readFile } from 'fs/promises'
@@ -237,6 +237,11 @@ export function registerIpcHandlers(sharedPtyManager: PtyManager, sharedTaskSche
       const msg = err instanceof Error ? err.message : String(err)
       return { success: false, output: msg }
     }
+  })
+
+  // ── Shell: open external URL ──
+  ipcMain.handle(IPC.SHELL_OPEN_EXTERNAL, async (_e, url: string) => {
+    shell.openExternal(url)
   })
 
   // ── Schedule handlers ──

--- a/desktop/src/preload/index.ts
+++ b/desktop/src/preload/index.ts
@@ -145,6 +145,8 @@ const api = {
   shell: {
     runCommand: (command: string, cwd: string) =>
       ipcRenderer.invoke(IPC.SHELL_RUN_COMMAND, command, cwd) as Promise<{ success: boolean; output: string }>,
+    openExternal: (url: string) =>
+      ipcRenderer.invoke(IPC.SHELL_OPEN_EXTERNAL, url),
   },
 
   mcp: {

--- a/desktop/src/renderer/connected/TerminalPanel.tsx
+++ b/desktop/src/renderer/connected/TerminalPanel.tsx
@@ -44,6 +44,7 @@ export function TerminalPanel({ ptyId, active }: Props) {
       resizePty={window.api.pty.resize}
       subscribePtyData={window.api.pty.onData}
       getBuffer={window.api.pty.getBuffer}
+      onLinkClick={window.api.shell.openExternal}
     />
   )
 }

--- a/desktop/src/shared/ipc-channels.ts
+++ b/desktop/src/shared/ipc-channels.ts
@@ -52,6 +52,7 @@ export const IPC = {
 
   // Shell operations
   SHELL_RUN_COMMAND: 'shell:run-command',
+  SHELL_OPEN_EXTERNAL: 'shell:open-external',
 
   // MCP orchestration
   MCP_GET_PORT: 'mcp:get-port',

--- a/packages/ui/src/components/Terminal/TerminalPanel.tsx
+++ b/packages/ui/src/components/Terminal/TerminalPanel.tsx
@@ -15,9 +15,10 @@ interface TerminalPanelProps {
   resizePty: (ptyId: string, cols: number, rows: number) => void
   subscribePtyData: (ptyId: string, cb: (data: string) => void) => () => void
   getBuffer?: (ptyId: string) => Promise<string>
+  onLinkClick?: (url: string) => void
 }
 
-export function TerminalPanel({ ptyId, active, fontSize, fontFamily, writePty, resizePty, subscribePtyData, getBuffer }: TerminalPanelProps) {
+export function TerminalPanel({ ptyId, active, fontSize, fontFamily, writePty, resizePty, subscribePtyData, getBuffer, onLinkClick }: TerminalPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const termDivRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<Terminal | null>(null)
@@ -75,7 +76,10 @@ export function TerminalPanel({ ptyId, active, fontSize, fontFamily, writePty, r
 
         const fitAddon = new FitAddon()
         term.loadAddon(fitAddon)
-        term.loadAddon(new WebLinksAddon())
+        term.loadAddon(new WebLinksAddon((_e, uri) => {
+          if (onLinkClick) onLinkClick(uri)
+          else window.open(uri)
+        }))
 
         term.open(termDiv)
 


### PR DESCRIPTION
## Summary
- WebLinksAddon's default `window.open` handler doesn't reliably open URLs in Electron
- Added `shell:open-external` IPC channel that uses Electron's `shell.openExternal`
- Wired it through preload → `window.api.shell.openExternal` → TerminalPanel's `onLinkClick` prop
- Falls back to `window.open` when `onLinkClick` isn't provided (e.g. Storybook)

## Test plan
- [ ] Click a URL in the terminal — should open in the default browser
- [ ] Verify links still render with underline styling on hover
- [ ] Confirm Storybook terminal still works (falls back to `window.open`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)