### PR TITLE
Ensure directories exist before writing files or spawning PTYs

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -9,9 +9,9 @@
     "build": "electron-vite build",
     "preview": "electron-vite preview",
     "test": "bunx playwright test --project=electron",
-    "rebuild": "bunx electron-rebuild",
+    "rebuild": "bunx @electron/rebuild",
     "dist": "electron-vite build && electron-builder --mac --arm64",
-    "postinstall": "bash scripts/patch-electron-dev.sh"
+    "postinstall": "bunx @electron/rebuild && bash scripts/patch-electron-dev.sh"
   },
   "keywords": [],
   "author": "",

--- a/desktop/src/main/cli-config.ts
+++ b/desktop/src/main/cli-config.ts
@@ -171,7 +171,9 @@ async function configCustom(ctx: ConfigContext): Promise<void> {
     }
   }
 
-  await writeFile(join(chatDir, custom.mcpConfig.file), JSON.stringify(config, null, 2), 'utf-8')
+  const configPath = join(chatDir, custom.mcpConfig.file)
+  await mkdir(join(configPath, '..'), { recursive: true })
+  await writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8')
 
   if (custom.instructionsFile && custom.instructionsFile !== 'AGENTS.md') {
     await linkInstructions(chatDir, custom.instructionsFile)

--- a/desktop/src/main/file-service.ts
+++ b/desktop/src/main/file-service.ts
@@ -1,11 +1,17 @@
-import { readFile as fsReadFile, writeFile as fsWriteFile } from 'fs/promises'
+import { readFile as fsReadFile, writeFile as fsWriteFile, mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
 
 export class FileService {
-  static async readFile(filePath: string): Promise<string> {
-    return fsReadFile(filePath, 'utf-8')
+  static async readFile(filePath: string): Promise<string | null> {
+    try {
+      return await fsReadFile(filePath, 'utf-8')
+    } catch {
+      return null
+    }
   }
 
   static async writeFile(filePath: string, content: string): Promise<void> {
+    await mkdir(join(filePath, '..'), { recursive: true })
     await fsWriteFile(filePath, content, 'utf-8')
   }
 }

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -87,7 +87,7 @@ export function registerIpcHandlers(sharedPtyManager: PtyManager, sharedTaskSche
   ipcMain.handle(IPC.PTY_CREATE, async (_e, workingDir: string, shell?: string, extraEnv?: Record<string, string>, command?: string[]) => {
     const win = BrowserWindow.fromWebContents(_e.sender)
     if (!win) throw new Error('No window found')
-    const ptyId = ptyManager.create(workingDir, win.webContents, shell, command, undefined, extraEnv)
+    const ptyId = await ptyManager.create(workingDir, win.webContents, shell, command, undefined, extraEnv)
     ptyManager.onExit(ptyId, (exitCode) => {
       if (!win.isDestroyed()) {
         win.webContents.send(`${IPC.PTY_EXIT}:${ptyId}`, exitCode)

--- a/desktop/src/main/pty-manager.ts
+++ b/desktop/src/main/pty-manager.ts
@@ -1,4 +1,5 @@
 import * as pty from 'node-pty'
+import { mkdir } from 'node:fs/promises'
 import { WebContents } from 'electron'
 import { IPC } from '../shared/ipc-channels'
 
@@ -19,7 +20,7 @@ export class PtyManager {
   private ptys = new Map<string, PtyInstance>()
   private nextId = 0
 
-  create(workingDir: string, webContents: WebContents, shell?: string, command?: string[], initialWrite?: string, extraEnv?: Record<string, string>): string {
+  async create(workingDir: string, webContents: WebContents, shell?: string, command?: string[], initialWrite?: string, extraEnv?: Record<string, string>): Promise<string> {
     const id = `pty-${++this.nextId}`
 
     let file: string
@@ -32,6 +33,7 @@ export class PtyManager {
       args = []
     }
 
+    await mkdir(workingDir, { recursive: true })
     const { CLAUDECODE, ...cleanEnv } = process.env
     const proc = pty.spawn(file, args, {
       name: 'xterm-256color',


### PR DESCRIPTION
## Summary
- Fix `posix_spawnp failed` error by ensuring cwd exists before `pty.spawn()` via `await mkdir({recursive: true})`
- Add `mkdir` guards before all file writes that assume parent directories exist (terminal-buffer, custom CLI configs)
- Make `FileService.readFile` return `null` for missing files instead of throwing; `writeFile` ensures parent dir
- Switch from deprecated `electron-rebuild` (node-gyp 9.x, requires Python `distutils`) to `@electron/rebuild` (node-gyp 11.x, works with Python 3.12+) — rebuild now works out of the box

## Before

Creating a chat would crash with:

```
Error occurred in handler for 'chat-registry:create': Error: posix_spawnp failed.
    at new UnixTerminal (node_modules/node-pty/lib/unixTerminal.js:92:24)
    at Module.spawn (node_modules/node-pty/lib/index.js:30:12)
    at PtyManager.create (desktop/out/main/index.js:1646:33)
    at ChatRegistry.createChat (desktop/out/main/index.js:2062:31)
```

Opening Settings would throw for every optional defaults file:

```
Error occurred in handler for 'fs:read-file': Error: ENOENT: no such file or directory,
    open '/Users/eric/.parlour/llm-defaults/claude/settings.local.json'
Error occurred in handler for 'fs:read-file': Error: ENOENT: no such file or directory,
    open '/Users/eric/.parlour/llm-defaults/codex/config.toml'
Error occurred in handler for 'fs:read-file': Error: ENOENT: no such file or directory,
    open '/Users/eric/.parlour/llm-defaults/opencode/opencode.json'
```

Running `bun run rebuild` would fail on Python 3.12+:

```
ModuleNotFoundError: No module named 'distutils'
✖ Rebuild Failed
```

## Test plan
- [ ] `bun install` in `desktop/` triggers native rebuild automatically
- [ ] `bun dev` starts without `posix_spawnp` errors
- [ ] Creating a new chat spawns PTY successfully
- [ ] No ENOENT errors for optional llm-defaults files in console
- [ ] Custom CLI configs with nested paths (e.g. `.aider/config.json`) write correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)